### PR TITLE
Updated electrode configuration to standardize contact labels by default

### DIFF
--- a/bptools/jacksheet.py
+++ b/bptools/jacksheet.py
@@ -1,7 +1,8 @@
 import pandas as pd
+from bptools.util import standardize_label
 
 
-def read_jacksheet(filename, ignore_ecg=True):
+def read_jacksheet(filename, ignore_ecg=True, standardize_labels=True):
     """Utility function to read a jacksheet.
 
     Parameters
@@ -9,6 +10,8 @@ def read_jacksheet(filename, ignore_ecg=True):
     filename : str
     ignore_ecg : bool
         Omit heart rate channels labeled as ECG/EKG.
+    standarize_labels: bool
+        Standarize contact labels when reading in the jacksheet
 
     Returns
     -------
@@ -30,7 +33,10 @@ def read_jacksheet(filename, ignore_ecg=True):
         .rename(columns={0: 'electrode'})
     js = pd.concat([df, electrodes], axis=1)
 
+    if standardize_labels:
+        js['label'] = js['label'].apply(standardize_label)
+
     if ignore_ecg:
-        return js[~js.label.str.startswith('ECG') & ~js.label.str.startswith('EKG')]
-    else:
-        return js
+        js =  js[~js.label.str.startswith('ECG') & ~js.label.str.startswith('EKG')]
+    
+    return js

--- a/bptools/odin/config.py
+++ b/bptools/odin/config.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cover
 import numpy as np
 import pandas as pd
 
-from bptools.util import FromSeriesMixin
+from bptools.util import FromSeriesMixin, standardize_label
 from bptools.jacksheet import read_jacksheet
 from bptools.pairs import create_pairs, create_monopolar_pairs
 
@@ -328,7 +328,7 @@ class ElectrodeConfig(object):
 
         return config
 
-    def read_config_file(self, filename):
+    def read_config_file(self, filename, standardize_labels=True):
         """Populate the instance from an Odin electrode configuration file.
 
         Parameters
@@ -410,6 +410,15 @@ class ElectrodeConfig(object):
                     'name', 'anode', 'cathode'
                 ]).iterrows()
             ]
+
+            # Optionally standardize labels for contacts, sense channels, and stim channels
+            if standardize_labels:
+                for contact in self.contacts:
+                    contact.label = standardize_label(contact.label)
+                for sense_channel in self.sense_channels:
+                    sense_channel.name = standardize_label(sense_channel.name)
+                for stim_channel in self.stim_channels:
+                    stim_channel.name = standardize_label(stim_channel.name)
 
     def to_csv(self, outfile=None):
         """Export as an Odin CSV electrode configuration file.

--- a/bptools/test/test_jacksheet.py
+++ b/bptools/test/test_jacksheet.py
@@ -8,9 +8,10 @@ from bptools.test import datafile
                  'R1306E_jacksheet.txt']
 )
 @pytest.mark.parametrize('ignore_ecg', [True, False])
-def test_read_jacksheet(filename, ignore_ecg):
+@pytest.mark.parametrize('standardize_labels', [True, False])
+def test_read_jacksheet(filename, ignore_ecg, standardize_labels):
     jacksheet = datafile(filename)
-    js = read_jacksheet(jacksheet, ignore_ecg=ignore_ecg)
+    js = read_jacksheet(jacksheet, ignore_ecg=ignore_ecg, standardize_labels=standardize_labels)
 
     if filename.startswith('simple'):
         assert len(js) == 35
@@ -18,5 +19,7 @@ def test_read_jacksheet(filename, ignore_ecg):
         assert len(js) == 128 if not ignore_ecg else 126
     elif filename.startswith('R1306E'):
         assert len(js) == 122 if not ignore_ecg else 120
+        labels = js.label.values
+        assert ('2RD1' in labels) if standardize_labels else ('2Rd1' in labels)
 
     assert 'electrode' in js.columns

--- a/bptools/test/test_util.py
+++ b/bptools/test/test_util.py
@@ -1,5 +1,6 @@
+import pytest
 import pandas as pd
-from bptools.util import FromSeriesMixin
+from bptools.util import FromSeriesMixin, standardize_label
 
 
 def test_from_series_mixin():
@@ -14,3 +15,22 @@ def test_from_series_mixin():
     assert instance.a == 1
     assert instance.b == 2
     assert instance.c == 3
+
+
+@pytest.mark.parametrize("input,expected_output",[
+    ("LAD1", "LAD1"),
+    ("LAD1-LAD2", "LAD1-LAD2"),
+    ("RHD10-RHD11", "RHD10-RHD11"),
+    ("LAD 1", "LAD1"),
+    ("LAD \t 1", "LAD1"),
+    ("LAD \n 1", "LAD1"),
+    ("LAD01", "LAD1"),
+    ("LAD09-LAD10", "LAD9-LAD10"),
+    ("RAHDmicro1", "RAHDMICRO1"),
+    ("RAHDmicro9-RAHDmicro10", "RAHDMICRO9-RAHDMICRO10"),
+    ("LAd1", "LAD1"),
+    ("RAHDmicro01-RAHDmicro2", "RAHDMICRO1-RAHDMICRO2")
+])
+def test_standardize_label(input, expected_output):
+    assert standardize_label(input) == expected_output
+    return

--- a/bptools/util.py
+++ b/bptools/util.py
@@ -14,3 +14,48 @@ class FromSeriesMixin(object):
             for attr, value in s.iteritems()
         }
         return cls(**kwargs)
+
+
+def standardize_label(label):
+    """ Utility function to standardize a contact label
+
+    Given either a monopolar or bipolar contact label returns the label in a standardized format:
+        1. All uppercase characters
+        2. No whitespace
+        3. No leading zeros for lead numbers
+
+    Parameters
+    ----------
+    label: str
+        The contact label to be standardized
+
+    Returns
+    -------
+    final_label: str
+        The standardized contact label
+
+    Notes
+    -----
+    Makes it easier to compare labels across differneet sources when they are stored consistently
+
+    """
+    # Remove whitepsace characters
+    label = ''.join(label.split())
+
+    # Use recursion for bipolars
+    if label.find("-") != -1:
+        tokens = label.split("-")
+        left = standardize_label(tokens[0])
+        right = standardize_label(tokens[1])
+        return "-".join([left, right])
+
+    final_label = label
+
+    # Some contacts have a leading 0 (LAD01), so remove it
+    if label[-2] == "0":
+        final_label = label[:-2] + label[-1]
+
+    # All characters should be uppercase 
+    final_label = final_label.upper()
+
+    return final_label


### PR DESCRIPTION
Added standardize_label utility function to util.py and updated the electrode configuration class methods to standardize labels for contacts, sense channels, and stim channels by default. Ran test suite locally before submitting this. Any thoughts on how to do the standardization without 3 for loops when creating from an odin config file? That's the ugly part of this minor update.