### PR TITLE
Fix to issue #6. Standardize by default again.

### DIFF
--- a/bptools/odin/config.py
+++ b/bptools/odin/config.py
@@ -336,7 +336,7 @@ class ElectrodeConfig(object):
 
         return config
 
-    def read_config_file(self, filename, standardize_labels=False):
+    def read_config_file(self, filename, standardize_labels=True):
         """Populate the instance from an Odin electrode configuration file.
 
         Parameters

--- a/bptools/test/test_odin.py
+++ b/bptools/test/test_odin.py
@@ -143,9 +143,12 @@ class TestElectrodeConfig:
         assert all([ec.sense_channels[i] == ec2.sense_channels[i] for i in range(len(ec.sense_channels))])
         assert all([ec.stim_channels[i] == ec2.stim_channels[i] for i in range(len(ec.stim_channels))])
 
-    def test_creation_methods(self):
-        ec = ElectrodeConfig(filename=datafile('R1306E_22SEP2017L0M0NOSTIM.csv'))
-        ec2 = ElectrodeConfig.from_jacksheet(datafile('R1306E_jacksheet.txt'), scheme='monopolar')
+    @pytest.mark.parametrize('odin,jacksheet,scheme',[ 
+        ('R1306E_22SEP2017L0M0NOSTIM.csv', 'R1306E_jacksheet.txt', 'monopolar'),]
+    )
+    def test_creation_methods(self, odin, jacksheet, scheme):
+        ec = ElectrodeConfig(filename=datafile(odin))
+        ec2 = ElectrodeConfig.from_jacksheet(datafile(jacksheet), scheme=scheme)
 
         assert len(ec.contacts) == len(ec2.contacts)
         assert len(ec.sense_channels) == len(ec2.sense_channels)

--- a/bptools/test/test_util.py
+++ b/bptools/test/test_util.py
@@ -20,6 +20,9 @@ def test_from_series_mixin():
 @pytest.mark.parametrize("input,expected_output",[
     ("LAD1", "LAD1"),
     ("LAD1-LAD2", "LAD1-LAD2"),
+    ("2RD1", "2RD1"),
+    ("1LD1CR", "1LD1CR"),
+    ("23LAD1", "23LAD1"),
     ("RHD10-RHD11", "RHD10-RHD11"),
     ("LAD 1", "LAD1"),
     ("LAD \t 1", "LAD1"),

--- a/bptools/util.py
+++ b/bptools/util.py
@@ -39,6 +39,10 @@ def standardize_label(label):
     Makes it easier to compare labels across differneet sources when they are stored consistently
 
     """
+    # Update type of label to be string. Occasionally, pandas will infer a long
+    # type for contacts starting with numbers
+    label = str(label)
+
     # Remove whitepsace characters
     label = ''.join(label.split())
 

--- a/bptools/util.py
+++ b/bptools/util.py
@@ -36,7 +36,7 @@ def standardize_label(label):
 
     Notes
     -----
-    Makes it easier to compare labels across differneet sources when they are stored consistently
+    Makes it easier to compare labels across different sources when they are stored consistently
 
     """
     # Update type of label to be string. Occasionally, pandas will infer a long


### PR DESCRIPTION
Explicitly converting contact labels to string before standardizing. Standardizing by default again. Parameterized test_creation_methods so more jacksheet/odin config file pairs could be tested. This is a fix to issue #6 